### PR TITLE
fix: CpuProver nested runtime panic and CI protoc/build fixes

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,9 +11,17 @@ runs:
       shell: bash
       run: |
         sudo yum update -y
-        sudo yum install -y gcc gcc-c++ make pkg-config openssl-devel clang llvm llvm-devel clang-devel perl perl-core
+        sudo yum install -y gcc gcc-c++ make pkg-config openssl-devel clang llvm llvm-devel clang-devel perl perl-core unzip
         gcc --version
         perl --version
+        # Install protoc v25.3 directly to /usr/local/bin (yum version too old)
+        curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-linux-x86_64.zip
+        unzip -o protoc-25.3-linux-x86_64.zip -d /tmp/protoc-install
+        sudo cp /tmp/protoc-install/bin/protoc /usr/local/bin/protoc
+        sudo chmod 755 /usr/local/bin/protoc
+        sudo cp -r /tmp/protoc-install/include/google /usr/local/include/
+        which protoc
+        protoc --version
         
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/elf.yml
+++ b/.github/workflows/elf.yml
@@ -16,16 +16,32 @@ jobs:
     runs-on: [self-hosted, Linux, X64, eks, mantle-succinct, "mainnetv2"]
 
     steps:
+      - name: Fix workspace permissions
+        run: |
+          # Docker builds leave root-owned files; fix before checkout so it can clean the workspace.
+          docker run --rm -v "$GITHUB_WORKSPACE:/workspace" alpine \
+            sh -c "chmod -R 777 /workspace || true"
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-      - name: Install SP1 toolchain
+      - name: Install Rust and SP1 toolchain
         run: |
+          # Install protoc v25.3 directly to /usr/local/bin (yum version too old)
+          curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-linux-x86_64.zip
+          unzip -o protoc-25.3-linux-x86_64.zip -d /tmp/protoc-install
+          sudo cp /tmp/protoc-install/bin/protoc /usr/local/bin/protoc
+          sudo chmod 755 /usr/local/bin/protoc
+          sudo cp -r /tmp/protoc-install/include/google /usr/local/include/
+          which protoc
+          protoc --version
+          # Install Rust
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source $HOME/.cargo/env
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           curl -L https://sp1.succinct.xyz | bash
           ~/.sp1/bin/sp1up -v 6.1.0
           ~/.sp1/bin/cargo-prove prove --version
-          source ~/.bashrc
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Verify the OP Succinct binaries
@@ -45,3 +61,10 @@ jobs:
           else
             echo "✅ ELF files remained unchanged"
           fi
+      - name: Fix Docker file permissions
+        if: always()
+        run: |
+          # Docker builds create root-owned files; fix permissions so the next
+          # workflow's checkout step can clean the workspace without EACCES errors.
+          docker run --rm -v ${{ github.workspace }}:/workspace alpine \
+            sh -c "chown -R $(id -u):$(id -g) /workspace/target || true"

--- a/scripts/utils/bin/cost_estimator.rs
+++ b/scripts/utils/bin/cost_estimator.rs
@@ -67,8 +67,6 @@ async fn execute_blocks_and_write_stats_csv<H: OPSuccinctHost>(
     fs::File::create(&report_path).unwrap();
     let report_path = report_path.canonicalize().unwrap();
 
-    let prover = CpuProver::new();
-
     // Run the host tasks in parallel using join_all
     let handles = host_args.iter().map(|host_args| {
         let host_args = host_args.clone();
@@ -85,48 +83,56 @@ async fn execute_blocks_and_write_stats_csv<H: OPSuccinctHost>(
         .map(|r| r.unwrap())
         .collect::<Vec<_>>();
 
-    let execution_inputs = stdins.into_iter().zip(block_data.iter()).collect::<Vec<_>>();
+    let execution_inputs = stdins.into_iter().zip(block_data.into_iter()).collect::<Vec<_>>();
 
     // Execute the program for each block range in parallel.
-    execution_inputs.par_iter().for_each(|(sp1_stdin, (range, block_data))| {
-        let result = prover
-            .execute(Elf::Static(get_range_elf_embedded()), sp1_stdin.clone())
-            .calculate_gas(true)
-            .deferred_proof_verification(false)
-            .run();
+    // Use spawn_blocking to avoid nesting a Tokio runtime — CpuProver internally
+    // creates its own runtime, which panics if called from within an async context.
+    let report_path_clone = report_path.clone();
+    tokio::task::spawn_blocking(move || {
+        let prover = CpuProver::new();
 
-        if let Some(err) = result.as_ref().err() {
-            log::warn!(
-                "Failed to execute blocks {:?} - {:?} because of {:?}. Reduce your `batch-size` if you're running into OOM issues on SP1.",
-                range.start,
-                range.end,
-                err
-            );
-            return;
-        }
+        execution_inputs.par_iter().for_each(|(sp1_stdin, (range, block_data))| {
+            let result = prover
+                .execute(Elf::Static(get_range_elf_embedded()), sp1_stdin.clone())
+                .calculate_gas(true)
+                .deferred_proof_verification(false)
+                .run();
 
-        let (_, report) = result.unwrap();
+            if let Some(err) = result.as_ref().err() {
+                log::warn!(
+                    "Failed to execute blocks {:?} - {:?} because of {:?}. Reduce your `batch-size` if you're running into OOM issues on SP1.",
+                    range.start,
+                    range.end,
+                    err
+                );
+                return;
+            }
 
-        let execution_stats = ExecutionStats::new(0, block_data, &report, 0, 0);
+            let (_, report) = result.unwrap();
 
-        let mut file = OpenOptions::new()
-            .read(true)
-            .append(true)
-            .open(&report_path)
-            .unwrap();
+            let execution_stats = ExecutionStats::new(0, block_data, &report, 0, 0);
 
-        // Writes the headers only if the file is empty.
-        let needs_header = file.seek(std::io::SeekFrom::End(0)).unwrap() == 0;
+            let mut file = OpenOptions::new()
+                .read(true)
+                .append(true)
+                .open(&report_path_clone)
+                .unwrap();
 
-        let mut csv_writer = csv::WriterBuilder::new()
-            .has_headers(needs_header)
-            .from_writer(file);
+            // Writes the headers only if the file is empty.
+            let needs_header = file.seek(std::io::SeekFrom::End(0)).unwrap() == 0;
 
-        csv_writer
-            .serialize(execution_stats.clone())
-            .expect("Failed to write execution stats to CSV.");
-        csv_writer.flush().expect("Failed to flush CSV writer.");
-    });
+            let mut csv_writer = csv::WriterBuilder::new()
+                .has_headers(needs_header)
+                .from_writer(file);
+
+            csv_writer
+                .serialize(execution_stats.clone())
+                .expect("Failed to write execution stats to CSV.");
+            csv_writer.flush().expect("Failed to flush CSV writer.");
+        });
+    })
+    .await?;
 
     info!("Execution is complete.");
 


### PR DESCRIPTION
## Summary

- **fix(cost_estimator):** Move CpuProver execution into `tokio::task::spawn_blocking()` to avoid "Cannot start a runtime from within a runtime" panic. SP1's CpuProver internally creates its own Tokio runtime, which panics when called from an existing async context. Also fix `block_data` lifetime to satisfy `'static` bound required by `spawn_blocking`.
- **fix(ci/setup):** Install protoc v25.3 from GitHub releases and copy protobuf include files to `/usr/local/include/`, fixing "google/protobuf/empty.proto not found" build errors for `sp1-prover-types`.
- **fix(ci/elf):** Install Rust before SP1 toolchain, install protoc with includes, and fix Docker root-owned file permissions that cause EACCES on subsequent runs.

## Test plan

- [x] `cost-estimator-manual.yml` workflow passes on `mantle-xyz/mantle-succinct` with these changes